### PR TITLE
Remove puppet references in the documentation

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -36,9 +36,6 @@ You will also need to choose whether you want to deploy you service as a
 [docker container](docker) (recommended) or install from
 [packages](packages).
 
-In case you chose to install from [packages](packages) you can have a look
-at the [IAM puppet module to deploy and configure the service](puppet-module).
-
 And finally, you will have to setup a minimal IAM configuration and change the
 administrator password for the newly configured IAM service; more on this
 [in the basic configuration section](basic_setup).

--- a/content/en/docs/getting-started/packages/_index.md
+++ b/content/en/docs/getting-started/packages/_index.md
@@ -67,21 +67,33 @@ To access the service logs, use the following command:
 $ sudo journalctl -fu iam-login-service
 ```
 
-## Automated provisioning with Puppet
+### Deployment Tips
+In headless servers, running `haveged` daemon is recommended to generate more entropy.
+Before running the IAM login service, check the available entropy with:
 
+```shell
+$ cat /proc/sys/kernel/random/entropy_avail
+```
 
-The IAM login service Puppet module can be  found [here][puppet-iam-repo].
-The module configures the IAM Login Service packages installation,
-configuration and the automatic generation of the JWK keystore.
+If the obtained value is less than 1000, then `haveged` daemon is mandatory.
 
-The setup of the MySQL database used by the service as well as the setup of the
-reverse proxy are **not covered** by this module.
+Install EPEL repository:
 
-However, the module provides an example of setup of both the Login Service and
-NginX as reverse proxy, using the official NginX Puppet module.
+```shell
+$ sudo yum install -y epel-release
+```
 
-For more detailed information about the Indigo IAM Puppet module usage, see the
-documentation in the [Github repository][puppet-iam-repo].
+Install Haveged:
 
-[puppet-iam-repo]: https://github.com/indigo-iam/puppet-indigo-iam
+```shell
+$ sudo yum install -y haveged
+```
+
+Enable and run the `haveged` daemon with:
+
+```shell
+$ sudo systemctl enable haveged
+$ sudo systemctl start haveged
+```
+
 [iam-pkg-repo]: https://indigo-iam.github.io/repo


### PR DESCRIPTION
* removed puppet from the [Getting Started](https://indigo-iam.github.io/v/current/docs/getting-started/) page;
* removed puppet from the [Deployment with Packages](https://indigo-iam.github.io/v/current/docs/getting-started/packages/#automated-provisioning-with-puppet) page;
* added _Deployment Tips_ to the [Deployment with Packages](https://indigo-iam.github.io/v/current/docs/getting-started/packages/#automated-provisioning-with-puppet) page.
  I have basically found this info in the [puppet repo](https://github.com/indigo-iam/puppet-indigo-iam#deployment-tips) and I guess it is useful to include it in the doc.