### PR TITLE
Example how to add proxycert

### DIFF
--- a/content/en/docs/reference/api/proxycert-api/_index.md
+++ b/content/en/docs/reference/api/proxycert-api/_index.md
@@ -7,19 +7,7 @@ weight: 1
 IAM provides a RESTful API that can be used to download the X.509 proxy certificate previously uploaded in IAM dashboard by the user. \
 This is a plain proxy obtained by running `voms-proxy-init` command.
 
-The API has been added mainly for the integration of IAM with the [RCAuth.eu][RCauth] online certificate authority, but users can also upload their own long lived proxy certificate
-
-```bash
-grid-proxy-init -hours 8760:0
-( echo -n '{"certificate_chain": "'; cat "/tmp/x509up_u$(id -u)" | sed 's/$/\\n/' | tr -d '\n'; echo -n '"}' ) \
-  | curl -s -XPUT \
-         -H 'Content-Type: application/json' \
-         -H "Authorization: Bearer ${BT}" \
-         -d client_id=${CLIENT_ID} \
-         -d client_secret=${CLIENT_SECRET} \
-         -T - \
-         https://localhost:8080/iam/account/me/proxycert
-```
+The API has been added mainly for the integration of IAM with the [RCAuth.eu][RCauth] online certificate authority or to upload certificate users can use [IAM Account Proxy Certificate API](/docs/reference/api/account-api/#proxy-certificate).
 
 The `proxy:generate` OAuth scope is required to access this API. \
 Note that this scope is restricted in the default IAM configuration,
@@ -38,7 +26,8 @@ curl -s -X POST -H "Authorization: Bearer ${BT}" \
 ```
 
 The user can request a specific lifetime of the proxy 
-that is less than or equal to the maximum lifetime of the proxy itself.
+that is less than or equal to the maximum lifetime of the proxy itself
+and also limited by IAM configuration options `max-lifetime-seconds`.
 
 IAM response:
 
@@ -51,7 +40,5 @@ IAM response:
   "certificate_chain": "-----BEGIN CERTIFICATE-----\nMI...lCU=\n-----END CERTIFICATE-----\n"
 }
 ```
-
-Maximum lifetime and key size can by configured in using `proxycert` configuration options `max-lifetime-seconds` and `key-size`.
 
 [RCauth]: http://rcauth.eu/

--- a/content/en/docs/reference/api/proxycert-api/_index.md
+++ b/content/en/docs/reference/api/proxycert-api/_index.md
@@ -7,7 +7,19 @@ weight: 1
 IAM provides a RESTful API that can be used to download the X.509 proxy certificate previously uploaded in IAM dashboard by the user. \
 This is a plain proxy obtained by running `voms-proxy-init` command.
 
-The API has been added mainly for the integration of IAM with the [RCAuth.eu][RCauth] online certificate authority.
+The API has been added mainly for the integration of IAM with the [RCAuth.eu][RCauth] online certificate authority, but users can also upload their own long lived proxy certificate
+
+```bash
+grid-proxy-init -hours 8760:0
+( echo -n '{"certificate_chain": "'; cat "/tmp/x509up_u$(id -u)" | sed 's/$/\\n/' | tr -d '\n'; echo -n '"}' ) \
+  | curl -s -XPUT \
+         -H 'Content-Type: application/json' \
+         -H "Authorization: Bearer ${BT}" \
+         -d client_id=${CLIENT_ID} \
+         -d client_secret=${CLIENT_SECRET} \
+         -T - \
+         https://localhost:8080/iam/account/me/proxycert
+```
 
 The `proxy:generate` OAuth scope is required to access this API. \
 Note that this scope is restricted in the default IAM configuration,
@@ -39,5 +51,7 @@ IAM response:
   "certificate_chain": "-----BEGIN CERTIFICATE-----\nMI...lCU=\n-----END CERTIFICATE-----\n"
 }
 ```
+
+Maximum lifetime and key size can by configured in using `proxycert` configuration options `max-lifetime-seconds` and `key-size`.
 
 [RCauth]: http://rcauth.eu/


### PR DESCRIPTION
Example how user can call `/iam/account/me/proxycert` endpoint to store long lived X.509 proxy.