### PR TITLE
Fix typo in VOMS AA documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ resources/
 node_modules/
 tech-doc-hugo
 .hugo_build.lock
+
+# IDE-specific directories
+.idea/

--- a/content/en/docs/tasks/deployment/voms/_index.md
+++ b/content/en/docs/tasks/deployment/voms/_index.md
@@ -114,9 +114,9 @@ voms:
     trust-anchors-dir: /etc/grid-security/certificates
     trust-anchors-refresh-interval-secs: 14400
   aa:
-    host: ${VOMS_AA_HOST}
-    port: ${VOMS_AA_PORT}
-    vo-name: ${VOMS_AA_VO}
+    host: ${VOMS_AA_HOST:undefined}
+    port: ${VOMS_AA_PORT:undefined}
+    vo-name: ${VOMS_AA_VO:undefined}
     use-legacy-fqan-encoding: ${VOMS_AA_USE_LEGACY_FQAN_ENCODING:true}
 ```
 

--- a/content/en/docs/tasks/deployment/voms/_index.md
+++ b/content/en/docs/tasks/deployment/voms/_index.md
@@ -70,7 +70,7 @@ following variables:
 
 - `VOMS_AA_HOST`: host name used to access the VOMS AA service
 - `VOMS_AA_PORT` VOMS AA port
-- `VOMS_AA_V0`: VO served by the VOMS AA service
+- `VOMS_AA_VO`: VO served by the VOMS AA service
 
 You also need to create a VOMS AA YAML configuration file with the content below (its content should
 be generic as it relies on standard environment variables used to configure the login service) and map it


### PR DESCRIPTION
Fix a typo in `VOMS_AA_VO` variable name introduced in #140. See https://github.com/indigo-iam/iam/issues/920 for details.