### PR TITLE
Notify VO Admins when a certificate is added by a profile

### DIFF
--- a/content/en/docs/reference/configuration/_index.md
+++ b/content/en/docs/reference/configuration/_index.md
@@ -383,6 +383,11 @@ IAM_NOTIFICATION_ADMIN_ADDRESS=indigo-alerts@localhost
 # all IAM admins or to notify-address-and-admins to combine the two behaviors
 IAM_NOTIFICATION_ADMIN_NOTIFICATION_POLICY=notify-address
 
+# Should notifications be made when a profiles certificate information is updated?
+# When set to true, notifications are made when a certifcate is linked or unlinked 
+# from a profile. It follows the notifcation strategy of notification policy.
+IAM_NOTIFICATION_CERTIFICATE=false
+
 # Notification policy for group requests. Default value notifies both
 # admins and group managers. Set to notify-gms if you want to notify only group managers
 IAM_NOTIFICATION_GROUP_MANAGER_NOTIFICATION_POLICY=notify-gms-and-admins

--- a/content/en/docs/reference/configuration/notifications/_index.md
+++ b/content/en/docs/reference/configuration/notifications/_index.md
@@ -24,6 +24,10 @@ notification:
   # - notify-admins: the notification arrives to  all IAM admins
   # - notify-address-and-admins: combine the two behaviors
   admin-notification-policy: notify-address
+  # When set to true, email notifications will be made, when a certificate is linked 
+  # or unlinked from a profile. The email strategy for this notification follows 
+  # the admin-notification-policy
+  certificateUpdate: false
   # Notification policy for group requests. Default value notifies both
   # admins and group managers. Set to notify-gms if you want to notify only group managers
   group-manager-notification-policy: notify-gms-and-admins


### PR DESCRIPTION
Updated the Notification page and the Configuration page with the information about the certificate update notification introduced in version [v1.13.0](https://github.com/indigo-iam/iam/releases/tag/v1.13.0).

It was introduced in pull request [972](https://github.com/indigo-iam/iam/pull/972) and prompted by issue [961](https://github.com/indigo-iam/iam/issues/961).